### PR TITLE
Potential fix for code scanning alert no. 77: Inefficient regular expression

### DIFF
--- a/themes/hugo-theme-altinn/static/js/evidencecodes.js
+++ b/themes/hugo-theme-altinn/static/js/evidencecodes.js
@@ -318,7 +318,7 @@ var EvidenceCodesDisplay = {
     // https://web.archive.org/web/20110806041156/http://forums.devshed.com/javascript-development-115/regexp-to-match-url-pattern-493764.html
     isValidUrl: function(urlString) {
         var urlPattern = new RegExp('^(https?:\\/\\/)?'+ // validate protocol
-        '((([a-z\\d]+(-[a-z\\d]+)*\\.)+[a-z]{2,}|'+ // validate domain name
+        '((([a-z\\d]+(-[a-z\\d]+)*\\.)+[a-z]{2,})|'+ // validate domain name
         '((\\d{1,3}\\.){3}\\d{1,3}))'+ // validate OR ip (v4) address
         '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*'+ // validate port and path
         '(\\?[;&a-z\\d%_.~+=-]*)?'+ // validate query string

--- a/themes/hugo-theme-altinn/static/js/evidencecodes.js
+++ b/themes/hugo-theme-altinn/static/js/evidencecodes.js
@@ -318,7 +318,7 @@ var EvidenceCodesDisplay = {
     // https://web.archive.org/web/20110806041156/http://forums.devshed.com/javascript-development-115/regexp-to-match-url-pattern-493764.html
     isValidUrl: function(urlString) {
         var urlPattern = new RegExp('^(https?:\\/\\/)?'+ // validate protocol
-        '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|'+ // validate domain name
+        '((([a-z\\d]+(-[a-z\\d]+)*\\.)+[a-z]{2,}|'+ // validate domain name
         '((\\d{1,3}\\.){3}\\d{1,3}))'+ // validate OR ip (v4) address
         '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*'+ // validate port and path
         '(\\?[;&a-z\\d%_.~+=-]*)?'+ // validate query string


### PR DESCRIPTION
Potential fix for [https://github.com/data-altinn-no/docs/security/code-scanning/77](https://github.com/data-altinn-no/docs/security/code-scanning/77)

**General strategy:**  
Remove ambiguity between sub-patterns by ensuring that parts of the regular expression that match domain parts (labels) do not allow overlapping alternatives or ambiguous repetition.

**Detailed fix:**  
- In file `themes/hugo-theme-altinn/static/js/evidencecodes.js`, find the regular expression defined in `isValidUrl` method (lines 320–325).
- The problematic section is:  
`([a-z\d]([a-z\d-]*[a-z\d])*)`  
This aims to match a domain label (e.g., `altinn` or `sub-domain`). According to the DNS spec, labels:  
  - start and end with alphanumeric (not hyphen),  
  - allow hyphens only in the middle.  
A safer way is to use:  
`[a-z\d](?:[a-z\d-]*[a-z\d])?`  
But even better, use:  
`[a-z\d]+(-[a-z\d]+)*`  
which means: must begin with one or more alphanumeric characters, can have zero or more groups of a hyphen followed by alphanumerics—ensuring hyphens never start/end a label and removing ambiguity.

**Implementation steps:**  
- Replace the domain label pattern in the RegExp creation with the safer pattern.
- No imports or new dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved URL validation to more accurately identify valid domain names and IP addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->