### PR TITLE
ci: pinning github action versions

### DIFF
--- a/.github/workflows/azure-static-web-apps-wonderful-mushroom-02abe3903.yml
+++ b/.github/workflows/azure-static-web-apps-wonderful-mushroom-02abe3903.yml
@@ -20,12 +20,12 @@ jobs:
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
       - name: Build And Deploy
         id: builddeploy
-        uses: Azure/static-web-apps-deploy@v1
+        uses: Azure/static-web-apps-deploy@1a947af9992250f3bc2e68ad0754c0b0c11566c9 # v1.0.0
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_WONDERFUL_MUSHROOM_02ABE3903 }}
           repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)
@@ -46,7 +46,7 @@ jobs:
     steps:
       - name: Close Pull Request
         id: closepullrequest
-        uses: Azure/static-web-apps-deploy@v1
+        uses: Azure/static-web-apps-deploy@1a947af9992250f3bc2e68ad0754c0b0c11566c9 # v1.0.0
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_WONDERFUL_MUSHROOM_02ABE3903 }}
           action: "close"


### PR DESCRIPTION
### Description
Pin github action versions

### Documentation
- [ ] Doc updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated GitHub Actions workflow configurations to use pinned action revisions for improved stability and reproducibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->